### PR TITLE
Add operator overloads and various functions to Vector2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ CMakeSettings.json
 # Visual Studio Code directories
 .vscode/
 build/
+
+# Build files
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CXX_STANDARD_REQUIRED ON)
 option(XU_BUILD_DOCS CACHE ON)
 option(XU_ENABLE_TESTS CACHE OFF)
 
+if (${FORCE_GNU_CXX17})
+    add_compile_options("--std=c++17")
+endif(${FORCE_GNU_CXX17}) 
+
 set(HEADERS
     "include/xu/core/Widget.hpp"
     "include/xu/core/Definitions.hpp"

--- a/include/xu/core/Vector2.hpp
+++ b/include/xu/core/Vector2.hpp
@@ -24,6 +24,9 @@
 
 #include "Definitions.hpp"
 
+#include <cmath>
+#include <cstdlib>
+#include <limits>
 #include <type_traits>
 
 namespace xu {
@@ -33,6 +36,76 @@ template <typename T> struct XU_API Vector2 {
   static_assert(std::is_arithmetic_v<T>, "T must be arithmetic type");
 
   T x, y;
+
+  constexpr Vector2() noexcept = default;
+  constexpr Vector2(T x, T y) noexcept : x(x), y(y) { };
+
+  static constexpr Vector2 Zero() { return Vector2<T>(0, 0); }
+
+  // Returns the size of the vector via pythagorean's theorem
+  constexpr float Magnitude() const {
+    return sqrtf(static_cast<float>(x*x + y*y));
+  }
+
+  // Returns the magnitude of the vector squared.
+  constexpr float Magnitude2() const {
+    return static_cast<float>(x*x + y*y);
+  }
+
+  // Returns a new vector pointing in the same direction but with a magnitude of 1
+  Vector2<T> Normalized() const {
+    return *this / Magnitude();
+  }
+
+  // Conversion operator
+  template<typename Cast_t>
+  explicit constexpr operator Vector2<Cast_t>() const {
+    return Vector2<Cast_t>(static_cast<Cast_t>(x), static_cast<Cast_t>(y));
+  }
+
+  // Equality operators
+  constexpr bool operator!=(const Vector2<T>& rhs) const { return !(*this == rhs); }
+  constexpr bool operator==(const Vector2<T>& rhs) const {
+    if constexpr (std::is_floating_point_v<T>) { // Epsilon equality for floating points
+      return std::abs(x - rhs.x) <= std::numeric_limits<T>::epsilon()
+          && std::abs(y - rhs.y) <= std::numeric_limits<T>::epsilon();
+    } else {
+      return x == rhs.x && y == rhs.y;
+    }
+  }
+
+  // Negation operator
+  Vector2<T> operator-() { auto temp = *this; return temp *= static_cast<T>(-1); }
+
+  // Vector|Vector arithmetic assignment operators
+  Vector2<T>& operator+=(const Vector2<T>& rhs) { x += rhs.x; y += rhs.y; return *this; }
+  Vector2<T>& operator-=(const Vector2<T>& rhs) { x -= rhs.x; y -= rhs.y; return *this; }
+  Vector2<T>& operator*=(const Vector2<T>& rhs) { x *= rhs.x; y *= rhs.y; return *this; }
+  Vector2<T>& operator/=(const Vector2<T>& rhs) { x /= rhs.x; y /= rhs.y; return *this; }
+
+  // Vector|Scalar arithmetic assignment operators
+  Vector2<T>& operator+=(T sclr) { return *this += Vector2<T>(sclr, sclr); }
+  Vector2<T>& operator-=(T sclr) { return *this -= Vector2<T>(sclr, sclr); }
+  Vector2<T>& operator*=(T sclr) { return *this *= Vector2<T>(sclr, sclr); }
+  Vector2<T>& operator/=(T sclr) { return *this /= Vector2<T>(sclr, sclr); }
+
+  // Vector|Vector arithmetic operators (defined in terms of += and friends)
+  Vector2<T> operator+(const Vector2<T>& rhs) const { auto temp = *this; return temp += rhs; }
+  Vector2<T> operator-(const Vector2<T>& rhs) const { auto temp = *this; return temp -= rhs; }
+  Vector2<T> operator*(const Vector2<T>& rhs) const { auto temp = *this; return temp *= rhs; }
+  Vector2<T> operator/(const Vector2<T>& rhs) const { auto temp = *this; return temp /= rhs; }
+
+  // Vector|Scalar arithmetic operators (defined in terms of += and friends)
+  Vector2<T> operator+(T sclr) const { auto temp = *this; return temp += sclr; } 
+  Vector2<T> operator-(T sclr) const { auto temp = *this; return temp -= sclr; } 
+  Vector2<T> operator*(T sclr) const { auto temp = *this; return temp *= sclr; } 
+  Vector2<T> operator/(T sclr) const { auto temp = *this; return temp /= sclr; }
+
+  // Friend Vector|Scalar arithmetic operators (so once can do, say 2 + Vector2<int>(3, 4) == Vector2<int>(5, 6))
+  friend Vector2<T> operator+(T sclr, const Vector2<T>& rhs) { return rhs + sclr; } 
+  friend Vector2<T> operator-(T sclr, const Vector2<T>& rhs) { return rhs - sclr; } 
+  friend Vector2<T> operator*(T sclr, const Vector2<T>& rhs) { return rhs * sclr; } 
+  friend Vector2<T> operator/(T sclr, const Vector2<T>& rhs) { return rhs / sclr; }
 };
 
 using IVector2 = Vector2<int>;

--- a/include/xu/core/Vector2.hpp
+++ b/include/xu/core/Vector2.hpp
@@ -75,7 +75,12 @@ template <typename T> struct XU_API Vector2 {
   }
 
   // Negation operator
-  Vector2<T> operator-() { auto temp = *this; return temp *= static_cast<T>(-1); }
+  Vector2<T> operator-() {
+    static_assert(std::is_signed_v<T>);
+
+    auto temp = *this;
+    return temp *= static_cast<T>(-1); 
+  }
 
   // Vector|Vector arithmetic assignment operators
   Vector2<T>& operator+=(const Vector2<T>& rhs) { x += rhs.x; y += rhs.y; return *this; }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -11,7 +11,7 @@ public:
 void TestVector2() {
   using xu::IVector2;
   using xu::FVector2;
-  
+
   IVector2 a(2, 5);
   IVector2 b{3, 6};
   IVector2 c = IVector2(4, 7);
@@ -33,14 +33,22 @@ void TestVector2() {
   assert(negA.x == -a.x && negA.y == -a.y);
 
   int s = 3;
-  IVector2 sumS = b + s;
-  IVector2 subS = b - s;
-  IVector2 multS = b * s;
-  IVector2 divS = b / s;
-  assert(sumS.x == b.x + s && sumS.y == b.y + s);
-  assert(subS.x == b.x - s && subS.y == b.y - s);
-  assert(multS.x == b.x * s && multS.y == b.y * s);
-  assert(divS.x == b.x / s && divS.y == b.y / s);
+  IVector2 sumS1 = b + s;
+  IVector2 sumS2 = s + b;
+  IVector2 subS1 = b - s;
+  IVector2 subS2 = s - b;
+  IVector2 multS1 = b * s;
+  IVector2 multS2 = s * b;
+  IVector2 divS1 = b / s;
+  IVector2 divS2 = s / b;
+  assert(sumS1.x == b.x + s && sumS1.y == b.y + s);
+  assert(subS1.x == b.x - s && subS1.y == b.y - s);
+  assert(multS1.x == b.x * s && multS1.y == b.y * s);
+  assert(divS1.x == b.x / s && divS1.y == b.y / s);
+  assert(sumS1 == sumS2);
+  assert(subS1 == subS2);
+  assert(multS1 == multS2);
+  assert(divS1 == divS2);
 
   assert(a == a);
   assert(a != b);
@@ -51,7 +59,6 @@ void TestVector2() {
   FVector2 f4{3.0f, 5.2f};
   assert(f1 == f4);
   assert(f1 != f2 && f1 != f3 && f2 != f3);
-
 
   printf("Vector test complete!\n");
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,4 +1,5 @@
-#include <xu/core/widget.hpp>
+#include <assert.h>
+#include <xu/core/Widget.hpp>
 
 class CustomWidget : public xu::Widget {
 public:
@@ -7,7 +8,59 @@ public:
   }
 };
 
+void TestVector2() {
+  using xu::IVector2;
+  using xu::FVector2;
+  
+  IVector2 a(2, 5);
+  IVector2 b{3, 6};
+  IVector2 c = IVector2(4, 7);
+
+  assert(a.x == 2 && a.y == 5);
+  assert(b.x == 3 && b.y == 6);
+  assert(c.x == 4 && c.y == 7);
+
+  IVector2 sumAB = a + b;
+  IVector2 subAB = a - b;
+  IVector2 multAB = a * b;
+  IVector2 divAB = a / b;
+  assert(sumAB.x == a.x + b.x && sumAB.y == a.y + b.y);
+  assert(subAB.x == a.x - b.x && subAB.y == a.y - b.y);
+  assert(multAB.x == a.x * b.x && multAB.y == a.y * b.y);
+  assert(divAB.x == a.x / b.x && divAB.y == a.y / b.y);
+
+  IVector2 negA = -a;
+  assert(negA.x == -a.x && negA.y == -a.y);
+
+  int s = 3;
+  IVector2 sumS = b + s;
+  IVector2 subS = b - s;
+  IVector2 multS = b * s;
+  IVector2 divS = b / s;
+  assert(sumS.x == b.x + s && sumS.y == b.y + s);
+  assert(subS.x == b.x - s && subS.y == b.y - s);
+  assert(multS.x == b.x * s && multS.y == b.y * s);
+  assert(divS.x == b.x / s && divS.y == b.y / s);
+
+  assert(a == a);
+  assert(a != b);
+
+  FVector2 f1{3.0f, 5.2f};
+  FVector2 f2{3.0f, 5.3f};
+  FVector2 f3{1.9f, 5.2f};
+  FVector2 f4{3.0f, 5.2f};
+  assert(f1 == f4);
+  assert(f1 != f2 && f1 != f3 && f2 != f3);
+
+
+  printf("Vector test complete!\n");
+}
+
 int main() {
   CustomWidget pog;
+
+  printf("Hello World Test\n");
+  TestVector2();
+
   return 0;
 }


### PR DESCRIPTION
Multiple operator overloads were implemented to the Vector2 struct.

Additions:

- Scalar operations are supported. So this means that one could do `Vector2<int>(5, 6) + 2` and that would give you `Vector2<int>(7, 8)`. This is supported for `+-*/`, and can be done either `vector op scalar` or `scalar op vector`. These are all defined in terms of the arithmetic assignment operators (so `+=` and friends).
- The negation operator
- I also added functions `Magnitude`, `Magnitude2`, `Normalized`, and 'DotProduct'.

Changes:
- `tests/main.cpp` I added test coverage for the Vector2 operations I added
- `.gitignore` I ignored `compile_commands.json` because clangd on my machine wants it to be in the root directory for some reason. >_>
- `CMakeLists.txt` I added a new flag `FORCE_GNU_CXX17` because CMake would not add the `-std=c++17` flag to the compilation commands on my Windows system, preventing it from building.